### PR TITLE
Additional changes to gem required by the Interlock MQTT project:

### DIFF
--- a/lib/paho-mqtt.rb
+++ b/lib/paho-mqtt.rb
@@ -11,7 +11,6 @@
 #
 # Contributors:
 #    Pierre Goudet - initial committer
-#    And Others.
 
 require "paho_mqtt/version"
 require "paho_mqtt/client"
@@ -101,6 +100,10 @@ module PahoMqtt
   Thread.abort_on_exception = true
 
   def logger=(logger_path)
+    if !logger_path
+      @logger = nil
+      return
+    end
     file           = File.open(logger_path, "a+")
     file.sync      = true
     log_file       = Logger.new(file)

--- a/lib/paho_mqtt/client.rb
+++ b/lib/paho_mqtt/client.rb
@@ -11,7 +11,6 @@
 #
 # Contributors:
 #    Pierre Goudet - initial committer
-#    And Others.
 
 require 'paho_mqtt/handler'
 require 'paho_mqtt/connection_helper'
@@ -97,9 +96,9 @@ module PahoMqtt
       @client_id = prefix << Array.new(lenght) { charset.sample }.join
     end
 
-    def config_ssl_context(cert_path, key_path, ca_path=nil)
+    def config_ssl_context(cert_path, key_path, ca_path=nil,alpn_protocols=nil)
       @ssl ||= true
-      @ssl_context = SSLHelper.config_ssl_context(cert_path, key_path, ca_path)
+      @ssl_context = SSLHelper.config_ssl_context(cert_path, key_path, ca_path,alpn_protocols)
     end
 
     def connect(host=@host, port=@port, keep_alive=@keep_alive, persistent=@persistent, blocking=@blocking)
@@ -189,6 +188,7 @@ module PahoMqtt
 
     def loop_misc
       if @connection_helper.check_keep_alive(@persistent, @handler.last_ping_resp, @keep_alive) == MQTT_CS_DISCONNECT
+        PahoMqtt.logger.debug("Reconnecting on loop_misc...") if PahoMqtt.logger?
         reconnect if check_persistence
       end
       @publisher.check_waiting_publisher

--- a/lib/paho_mqtt/connection_helper.rb
+++ b/lib/paho_mqtt/connection_helper.rb
@@ -11,7 +11,6 @@
 #
 # Contributors:
 #    Pierre Goudet - initial committer
-#    And Others.
 
 require 'socket'
 
@@ -87,8 +86,8 @@ module PahoMqtt
         else
           @socket = tcp_socket
         end
-      rescue StandardError
-        PahoMqtt.logger.warn("Could not open a socket with #{@host} on port #{@port}.") if PahoMqtt.logger?
+      rescue StandardError => e
+        PahoMqtt.logger.warn("Could not open a socket with #{@host} on port #{@port}. (#{e.inspect})") if PahoMqtt.logger?
       end
     end
 

--- a/lib/paho_mqtt/handler.rb
+++ b/lib/paho_mqtt/handler.rb
@@ -11,7 +11,6 @@
 #
 # Contributors:
 #    Pierre Goudet - initial committer
-#    And Others.
 
 module PahoMqtt
   class Handler
@@ -52,13 +51,13 @@ module PahoMqtt
       end
       return result
     end
-    
+
     def handle_packet(packet)
       PahoMqtt.logger.info("New packet #{packet.class} received.") if PahoMqtt.logger?
       type = packet_type(packet)
       self.send("handle_#{type}", packet)
     end
-    
+
     def register_topic_callback(topic, callback, &block)
       if topic.nil?
         PahoMqtt.logger.error("The topics where the callback is trying to be registered have been found nil.") if PahoMqtt.logger?

--- a/lib/paho_mqtt/publisher.rb
+++ b/lib/paho_mqtt/publisher.rb
@@ -11,7 +11,6 @@
 #
 # Contributors:
 #    Pierre Goudet - initial committer
-#    And Others.
 
 module PahoMqtt
   class Publisher

--- a/lib/paho_mqtt/sender.rb
+++ b/lib/paho_mqtt/sender.rb
@@ -11,7 +11,6 @@
 #
 # Contributors:
 #    Pierre Goudet - initial committer
-#    And Others.
 
 module PahoMqtt
   class Sender
@@ -34,11 +33,12 @@ module PahoMqtt
 
     def send_packet(packet)
       begin
-        @socket.write(packet.to_s) unless @socket.nil? || @socket.closed?
         @last_ping_req = Time.now
+        @socket.write(packet.to_s) unless @socket.nil? || @socket.closed?
         MQTT_ERR_SUCCESS
       end
-    rescue StandardError
+    rescue StandardError => e
+      PahoMqtt.logger.error("send_packet StandardError: #{e.inspect}") if PahoMqtt.logger?
       raise WritingException
     rescue IO::WaitWritable
       IO.select(nil, [@socket], nil, SELECT_TIMEOUT)

--- a/lib/paho_mqtt/subscriber.rb
+++ b/lib/paho_mqtt/subscriber.rb
@@ -11,7 +11,6 @@
 #
 # Contributors:
 #    Pierre Goudet - initial committer
-#    And Others.
 
 module PahoMqtt
   class Subscriber


### PR DESCRIPTION
* Added support for SSLContext#alpn_protocols (for AWS IoT 433 support)
* Pass SSL cert and key as strings instead of file paths
* Added log verbosity